### PR TITLE
🔀 :: 토큰 재발급 API

### DIFF
--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/exception/ExpiredRefreshTokenException.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/exception/ExpiredRefreshTokenException.kt
@@ -1,0 +1,6 @@
+package com.dol.domain.auth.exception
+
+import com.dol.global.error.ErrorStatus
+import com.dol.global.error.exception.HotSpotException
+
+class ExpiredRefreshTokenException(message: String) : HotSpotException(ErrorStatus.EXPIRED_REFRESH_TOKEN, message)

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/presentation/AuthController.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/presentation/AuthController.kt
@@ -5,10 +5,13 @@ import com.dol.domain.auth.presentation.data.request.SignUpRequest
 import com.dol.domain.auth.presentation.data.response.TokenResponse
 import com.dol.domain.auth.service.SignInService
 import com.dol.domain.auth.service.SignUpService
+import com.dol.domain.auth.service.TokenReissueService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -16,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth")
 class AuthController(
     private val signUpService: SignUpService,
-    private val signInService: SignInService
+    private val signInService: SignInService,
+    private val tokenReissueService: TokenReissueService
 ) {
 
     @PostMapping("/signup")
@@ -28,5 +32,10 @@ class AuthController(
     fun signIn(@RequestBody signInRequest: SignInRequest): ResponseEntity<TokenResponse> =
         signInService.execute(signInRequest)
             .let { ResponseEntity.ok(it) }
+
+    @PatchMapping("/reissue")
+    fun reissueToken(@RequestHeader refreshToken: String): ResponseEntity<TokenResponse> =
+        tokenReissueService.execute(refreshToken)
+            .let { ResponseEntity.ok(it)}
 
 }

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/presentation/AuthController.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/presentation/AuthController.kt
@@ -34,7 +34,7 @@ class AuthController(
             .let { ResponseEntity.ok(it) }
 
     @PatchMapping("/reissue")
-    fun reissueToken(@RequestHeader refreshToken: String): ResponseEntity<TokenResponse> =
+    fun reissueToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<TokenResponse> =
         tokenReissueService.execute(refreshToken)
             .let { ResponseEntity.ok(it)}
 

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/TokenReissueService.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/TokenReissueService.kt
@@ -1,0 +1,7 @@
+package com.dol.domain.auth.service
+
+import com.dol.domain.auth.presentation.data.response.TokenResponse
+
+interface TokenReissueService {
+    fun execute(refreshToken: String): TokenResponse
+}

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.dol.domain.auth.service.impl
+
+import com.dol.domain.auth.exception.ExpiredRefreshTokenException
+import com.dol.domain.auth.presentation.data.response.TokenResponse
+import com.dol.domain.auth.repository.RefreshTokenRepository
+import com.dol.domain.auth.service.TokenReissueService
+import com.dol.domain.user.exception.UserNotFoundException
+import com.dol.domain.user.repository.UserRepository
+import com.dol.global.security.jwt.TokenGenerator
+import com.dol.global.security.jwt.TokenParser
+import com.dol.global.security.jwt.common.exception.InvalidTokenTypeException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class TokenReissueServiceImpl(
+    private val tokenParser: TokenParser,
+    private val tokenGenerator: TokenGenerator,
+    private val userRepository: UserRepository,
+    private val refreshTokenRepository: RefreshTokenRepository
+) : TokenReissueService {
+    override fun execute(refreshToken: String): TokenResponse {
+        val parsedRefreshToken = tokenParser.parseRefreshTokenToken(refreshToken) ?: throw InvalidTokenTypeException("유효하지 않은 토큰입니다.")
+        val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken) ?: throw ExpiredRefreshTokenException("만료된 토큰입니다.")
+        val user = userRepository.findByIdOrNull(refreshTokenDomain.userIdx) ?: throw UserNotFoundException("사용자를 찾을 수 없습니다.")
+        val token = tokenGenerator.generateToken(user.idx, user.authority)
+        return TokenResponse(
+            accessToken = token.accessToken,
+            refreshToken = token.refreshToken,
+            accessTokenExp = LocalDateTime.now().plusSeconds(token.accessTokenExp),
+            refreshTokenExp = LocalDateTime.now().plusSeconds(token.refreshTokenExp),
+        )
+    }
+}

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
@@ -25,9 +25,12 @@ class TokenReissueServiceImpl(
     private val refreshTokenRepository: RefreshTokenRepository
 ) : TokenReissueService {
     override fun execute(refreshToken: String): TokenResponse {
-        val parsedRefreshToken = tokenParser.parseRefreshTokenToken(refreshToken) ?: throw InvalidTokenTypeException("유효하지 않은 토큰입니다.")
-        val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken) ?: throw ExpiredRefreshTokenException("만료된 토큰입니다.")
-        val user = userRepository.findByIdOrNull(refreshTokenDomain.userIdx) ?: throw UserNotFoundException("사용자를 찾을 수 없습니다.")
+        val parsedRefreshToken = tokenParser.parseRefreshTokenToken(refreshToken)
+            ?: throw InvalidTokenTypeException("유효하지 않은 토큰입니다. info : [ refreshToken = $refreshToken ]")
+        val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken)
+            ?: throw ExpiredRefreshTokenException("만료된 토큰입니다. info : [ refreshToken = $parsedRefreshToken ]")
+        val user = userRepository.findByIdOrNull(refreshTokenDomain.userIdx)
+            ?: throw UserNotFoundException("사용자를 찾을 수 없습니다.")
         val token = tokenGenerator.generateToken(user.idx, user.authority)
         refreshTokenRepository.delete(refreshTokenDomain)
         return TokenResponse(

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
@@ -28,9 +28,9 @@ class TokenReissueServiceImpl(
         val parsedRefreshToken = tokenParser.parseRefreshTokenToken(refreshToken)
             ?: throw InvalidTokenTypeException("유효하지 않은 토큰입니다. info : [ refreshToken = $refreshToken ]")
         val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken)
-            ?: throw ExpiredRefreshTokenException("만료된 토큰입니다. info : [ refreshToken = $parsedRefreshToken ]")
+            ?: throw ExpiredRefreshTokenException("만료된 토큰입니다.")
         val user = userRepository.findByIdOrNull(refreshTokenDomain.userIdx)
-            ?: throw UserNotFoundException("사용자를 찾을 수 없습니다.")
+            ?: throw UserNotFoundException("사용자를 찾을 수 없습니다. info : [ userIdx = $refreshTokenDomain.userIdx ]")
         val token = tokenGenerator.generateToken(user.idx, user.authority)
         refreshTokenRepository.delete(refreshTokenDomain)
         return TokenResponse(

--- a/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/auth/service/impl/TokenReissueServiceImpl.kt
@@ -1,9 +1,11 @@
 package com.dol.domain.auth.service.impl
 
+import com.dol.domain.auth.entity.RefreshToken
 import com.dol.domain.auth.exception.ExpiredRefreshTokenException
 import com.dol.domain.auth.presentation.data.response.TokenResponse
 import com.dol.domain.auth.repository.RefreshTokenRepository
 import com.dol.domain.auth.service.TokenReissueService
+import com.dol.domain.user.entity.User
 import com.dol.domain.user.exception.UserNotFoundException
 import com.dol.domain.user.repository.UserRepository
 import com.dol.global.security.jwt.TokenGenerator
@@ -27,6 +29,7 @@ class TokenReissueServiceImpl(
         val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken) ?: throw ExpiredRefreshTokenException("만료된 토큰입니다.")
         val user = userRepository.findByIdOrNull(refreshTokenDomain.userIdx) ?: throw UserNotFoundException("사용자를 찾을 수 없습니다.")
         val token = tokenGenerator.generateToken(user.idx, user.authority)
+        refreshTokenRepository.delete(refreshTokenDomain)
         return TokenResponse(
             accessToken = token.accessToken,
             refreshToken = token.refreshToken,

--- a/hotspot-api/src/main/kotlin/com/dol/global/security/SecurityConfig.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/global/security/SecurityConfig.kt
@@ -34,7 +34,9 @@ class SecurityConfig(
 
     private fun authorizeHttpRequests(http: HttpSecurity) {
         http.authorizeHttpRequests()
-            .mvcMatchers(HttpMethod.GET, "/").permitAll()
+            .mvcMatchers(HttpMethod.POST, "auth/signup").permitAll()
+            .mvcMatchers(HttpMethod.POST, "auth/signin").permitAll()
+            .mvcMatchers(HttpMethod.PATCH, "auth/reissue").permitAll()
             .anyRequest().permitAll()
     }
 

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/auth/entity/RefreshToken.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/auth/entity/RefreshToken.kt
@@ -11,7 +11,7 @@ data class RefreshToken(
     @Id
     val refreshToken: String,
 
-    val accountIdx: UUID,
+    val userIdx: UUID,
 
     @TimeToLive(unit = TimeUnit.SECONDS)
     val expiredAt: Long


### PR DESCRIPTION
## 💡 개요
+ 토큰 재발급 API를 구현하였습니다.
## 📃 작업내용
+ 토큰 재발급 service를 구현하였습니다.
+ SecurityConfig에서 회원가입,로그인,토큰 재발급과 같은 api를 추가했습니다.
## 🔀 변경사항
+ RefreshToken 엔티티에서 accountIdx를 userIdx로 변경하였습니다.
