### PR TITLE
🔀 :: 팔로우 API

### DIFF
--- a/hotspot-api/src/main/kotlin/com/dol/domain/follow/exception/AlreadyFollowException.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/follow/exception/AlreadyFollowException.kt
@@ -1,0 +1,6 @@
+package com.dol.domain.follow.exception
+
+import com.dol.global.error.ErrorStatus
+import com.dol.global.error.exception.HotSpotException
+
+class AlreadyFollowException(message: String) : HotSpotException(ErrorStatus.ALREADY_FOLLOW, message)

--- a/hotspot-api/src/main/kotlin/com/dol/domain/follow/presentation/FollowController.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/follow/presentation/FollowController.kt
@@ -1,0 +1,23 @@
+package com.dol.domain.follow.presentation
+
+import com.dol.domain.follow.presentation.data.request.FollowRequest
+import com.dol.domain.follow.service.FollowService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/follow")
+class FollowController(
+    private val followService: FollowService
+) {
+
+    @PostMapping
+    fun follow(@RequestBody followRequest: FollowRequest) : ResponseEntity<Void> =
+        followService.execute(followRequest)
+            .let { ResponseEntity.status(HttpStatus.CREATED).build() }
+
+}

--- a/hotspot-api/src/main/kotlin/com/dol/domain/follow/presentation/data/request/FollowRequest.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/follow/presentation/data/request/FollowRequest.kt
@@ -1,0 +1,8 @@
+package com.dol.domain.follow.presentation.data.request
+
+import java.util.UUID
+
+data class FollowRequest(
+    val toUserIdx: UUID,
+    val fromUserIdx: UUID
+)

--- a/hotspot-api/src/main/kotlin/com/dol/domain/follow/service/FollowService.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/follow/service/FollowService.kt
@@ -1,0 +1,7 @@
+package com.dol.domain.follow.service
+
+import com.dol.domain.follow.presentation.data.request.FollowRequest
+
+interface FollowService {
+    fun execute(followRequest: FollowRequest)
+}

--- a/hotspot-api/src/main/kotlin/com/dol/domain/follow/service/impl/FollowServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/follow/service/impl/FollowServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.dol.domain.follow.service.impl
+
+import com.dol.domain.follow.entity.Follow
+import com.dol.domain.follow.exception.AlreadyFollowException
+import com.dol.domain.follow.presentation.data.request.FollowRequest
+import com.dol.domain.follow.repository.FollowRepository
+import com.dol.domain.follow.service.FollowService
+import com.dol.domain.user.exception.UserNotFoundException
+import com.dol.domain.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class FollowServiceImpl(
+    private val userRepository: UserRepository,
+    private val followRepository: FollowRepository
+) : FollowService {
+    override fun execute(followRequest: FollowRequest) {
+        val toUser = userRepository.findByIdOrNull(followRequest.toUserIdx)
+            ?: throw UserNotFoundException("유저가 존재하지 않습니다.")
+        val fromUser = userRepository.findByIdOrNull(followRequest.fromUserIdx)
+            ?: throw UserNotFoundException("유저가 존재하지 않습니다.")
+        if (followRepository.existsByToUserAndFromUser(toUser, fromUser)) {
+            throw AlreadyFollowException("이미 팔로우한 유저 입니다.")
+        }
+
+        val follow = Follow(
+            idx = UUID.randomUUID(),
+            toUser = toUser,
+            fromUser = fromUser
+        )
+        followRepository.save(follow)
+    }
+}

--- a/hotspot-api/src/main/kotlin/com/dol/global/error/ErrorStatus.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/global/error/ErrorStatus.kt
@@ -25,4 +25,7 @@ enum class ErrorStatus(
     EXPIRED_ACCESS_TOKEN(401),
     EXPIRED_REFRESH_TOKEN(401),
 
+    // FOLLOW
+    ALREADY_FOLLOW(401)
+
 }

--- a/hotspot-api/src/main/kotlin/com/dol/global/security/SecurityConfig.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/global/security/SecurityConfig.kt
@@ -43,6 +43,10 @@ class SecurityConfig(
 
             // user
             .mvcMatchers(HttpMethod.GET, "user/my-page").authenticated()
+
+            // follow
+            .mvcMatchers(HttpMethod.POST, "/follow").authenticated()
+
             .anyRequest().permitAll()
     }
 

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/follow/entity/Follow.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/follow/entity/Follow.kt
@@ -1,15 +1,10 @@
 package com.dol.domain.follow.entity
 
 import com.dol.common.entity.BaseUUIDEntity
-import org.springframework.data.annotation.CreatedBy
-import org.springframework.data.annotation.CreatedDate
+import com.dol.domain.user.entity.User
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.time.LocalDateTime
 import java.util.*
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.EntityListeners
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 @EntityListeners(AuditingEntityListener::class)
@@ -17,12 +12,11 @@ class Follow(
     @Column(name = "idx", columnDefinition = "BINARY(16)", nullable = false)
     override val idx: UUID,
 
-    @Column(name = "user_idx", nullable = false)
-    val userIdx: UUID,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_idx")
+    val toUser: User,
 
-    @Column(name = "from_user_idx", nullable = false)
-    val fromUserIdx: UUID,
-
-    @CreatedDate
-    val createdAt: LocalDateTime
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_idx")
+    val fromUser: User
 ) : BaseUUIDEntity(idx)

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/follow/repository/FollowRepository.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/follow/repository/FollowRepository.kt
@@ -1,0 +1,10 @@
+package com.dol.domain.follow.repository
+
+import com.dol.domain.follow.entity.Follow
+import com.dol.domain.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface FollowRepository : JpaRepository<Follow, UUID> {
+    fun existsByToUserAndFromUser(toUser: User, fromUser: User): Boolean
+}

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/user/entity/User.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/user/entity/User.kt
@@ -1,6 +1,7 @@
 package com.dol.domain.user.entity
 
 import com.dol.common.entity.BaseUUIDEntity
+import com.dol.domain.follow.entity.Follow
 import com.dol.domain.user.enums.Authority
 import java.util.*
 import javax.persistence.*
@@ -8,7 +9,7 @@ import javax.persistence.*
 @Entity
 @Table(name = "user")
 class User(
-    @Column(name = "user_idx", columnDefinition = "BINARY(16)", nullable = false)
+    @Column(name = "idx", columnDefinition = "BINARY(16)", nullable = false)
     override val idx: UUID,
 
     @Column(nullable = false, length = 50)
@@ -23,7 +24,7 @@ class User(
     @Column(nullable = false, length = 20)
     val phoneNumber: String,
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     val password: String,
 
     @Column(nullable = false, length = 30)
@@ -36,5 +37,11 @@ class User(
     val profileUrl: String?,
 
     @Enumerated(EnumType.STRING)
-    val authority: Authority
+    val authority: Authority,
+
+    @OneToMany(mappedBy = "toUser")
+    val following: List<Follow> = listOf(),
+
+    @OneToMany(mappedBy = "fromUser")
+    val follower: List<Follow> = listOf()
 ): BaseUUIDEntity(idx)


### PR DESCRIPTION
## 💡 개요
+ 팔로우 API를 구현하였습니다.
## 📃 작업내용
+ follow와 user간의 연관관계 매핑을 설정하였습니다.
+ 이미 팔로우한 유저에 대한 예외처리를 추가하였습니다.
+ 팔로우 서비스를 구현하였습니다.
+ security config에 팔로우 API를 추가하였습니다.
## 🔀 변경사항
+ user 엔티티에서 password필드에 대한 length를 삭제하였습니다.
    + length를 30으로 설정하면 데이터베이스에서 컬럼의 크기가 VARCHAR(30)으로 컬럼 값보다 큰 인코딩된 password가 들어가지 않는 상황이 발생했습니다.
