### PR TITLE
42 🔀 :: 핫플레이스 리스트 API

### DIFF
--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/HotplaceController.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/HotplaceController.kt
@@ -1,8 +1,11 @@
 package com.dol.domain.hotplace.presentation
 
 import com.dol.domain.hotplace.presentation.data.request.CreateHotplaceRequest
+import com.dol.domain.hotplace.presentation.data.request.QueryHotplaceListRequest
+import com.dol.domain.hotplace.presentation.data.response.QueryHotplaceListResponse
 import com.dol.domain.hotplace.presentation.data.response.QueryHotplaceResponse
 import com.dol.domain.hotplace.service.CreateHotplaceService
+import com.dol.domain.hotplace.service.QueryHotplaceListService
 import com.dol.domain.hotplace.service.QueryHotplaceService
 import com.dol.domain.hotplace.service.RecommendHotplaceService
 import org.springframework.http.HttpStatus
@@ -15,7 +18,8 @@ import java.util.UUID
 class HotplaceController(
     private val createHotplaceService: CreateHotplaceService,
     private val queryHotplaceService: QueryHotplaceService,
-    private val recommendHotplaceService: RecommendHotplaceService
+    private val recommendHotplaceService: RecommendHotplaceService,
+    private val queryHotplaceListService: QueryHotplaceListService
 ) {
     @PostMapping
     fun createHotplace(@RequestBody createHotplaceRequest: CreateHotplaceRequest): ResponseEntity<Void> {
@@ -26,12 +30,18 @@ class HotplaceController(
     @GetMapping("/{idx}")
     fun queryHotplace(@PathVariable idx: UUID): ResponseEntity<QueryHotplaceResponse> {
         val response = queryHotplaceService.execute(idx)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 
     @PostMapping("/recommend/{idx}")
     fun recommendHotplace(@PathVariable idx: UUID): ResponseEntity<Void> {
         recommendHotplaceService.execute(idx)
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping("/list")
+    fun queryHotplaceList(@RequestBody queryHotplaceListRequest: QueryHotplaceListRequest): ResponseEntity<List<QueryHotplaceListResponse>> {
+        val response = queryHotplaceListService.execute(queryHotplaceListRequest)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 }

--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/data/request/QueryHotplaceListRequest.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/data/request/QueryHotplaceListRequest.kt
@@ -1,0 +1,6 @@
+package com.dol.domain.hotplace.presentation.data.request
+
+data class QueryHotplaceListRequest(
+    val longitude: Double,
+    val latitude: Double
+)

--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/data/response/QueryHotplaceListResponse.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/presentation/data/response/QueryHotplaceListResponse.kt
@@ -1,0 +1,9 @@
+package com.dol.domain.hotplace.presentation.data.response
+
+import java.util.UUID
+
+data class QueryHotplaceListResponse(
+    val idx: UUID,
+    val latitude: Double,
+    val longitude: Double
+)

--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/QueryHotplaceListService.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/QueryHotplaceListService.kt
@@ -1,0 +1,8 @@
+package com.dol.domain.hotplace.service
+
+import com.dol.domain.hotplace.presentation.data.request.QueryHotplaceListRequest
+import com.dol.domain.hotplace.presentation.data.response.QueryHotplaceListResponse
+
+interface QueryHotplaceListService {
+    fun execute(queryHotplaceListRequest: QueryHotplaceListRequest): List<QueryHotplaceListResponse>
+}

--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/impl/CreateHotplaceServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/impl/CreateHotplaceServiceImpl.kt
@@ -34,8 +34,8 @@ class CreateHotplaceServiceImpl(
             address = createHotplaceRequest.address,
             instagramId = createHotplaceRequest.instagramId,
             imgURL = createHotplaceRequest.imgURL,
-            longitude = longitude,
-            latitude = latitude,
+            longitude = longitude.toDouble(),
+            latitude = latitude.toDouble(),
             approveStatus = ApproveStatus.PENDING,
             user = user
         )

--- a/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/impl/QueryHotplaceListServiceImpl.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/domain/hotplace/service/impl/QueryHotplaceListServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.dol.domain.hotplace.service.impl
+
+import com.dol.domain.hotplace.presentation.data.request.QueryHotplaceListRequest
+import com.dol.domain.hotplace.presentation.data.response.QueryHotplaceListResponse
+import com.dol.domain.hotplace.repository.HotplaceRepository
+import com.dol.domain.hotplace.service.QueryHotplaceListService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class QueryHotplaceListServiceImpl(
+    private val hotplaceRepository: HotplaceRepository
+) : QueryHotplaceListService{
+    override fun execute(queryHotplaceListRequest: QueryHotplaceListRequest): List<QueryHotplaceListResponse> {
+        val hotplaces = queryHotplaceListRequest.run {
+            hotplaceRepository.findAllByLatitudeBetweenAndLongitudeBetween(
+                startLatitude = latitude - 0.0091,
+                endLatitude = latitude + 0.0091,
+                startLongitude = longitude - 0.0113,
+                endLongitude = longitude + 0.0113
+            )
+        }
+
+        val response = hotplaces.map {
+            QueryHotplaceListResponse(
+                idx = it.idx,
+                latitude = it.latitude,
+                longitude = it.longitude
+            )
+        }
+
+        return response
+    }
+}

--- a/hotspot-api/src/main/kotlin/com/dol/thirdparty/kakao/util/KakaoUtil.kt
+++ b/hotspot-api/src/main/kotlin/com/dol/thirdparty/kakao/util/KakaoUtil.kt
@@ -17,6 +17,7 @@ import org.springframework.web.util.UriComponentsBuilder
 class KakaoUtil(
     private val kakaoProperties: KakaoProperties
 ) {
+    private val logger = LoggerFactory.getLogger(KakaoUtil::class.java)
     fun addressInCoordinate(address: String): Pair<String, String> {
         val restTemplate = RestTemplate()
 

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/hotplace/entity/Hotplace.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/hotplace/entity/Hotplace.kt
@@ -3,6 +3,7 @@ package com.dol.domain.hotplace.entity
 import com.dol.common.entity.BaseUUIDEntity
 import com.dol.domain.hotplace.enums.ApproveStatus
 import com.dol.domain.user.entity.User
+import java.math.BigDecimal
 import java.util.UUID
 import javax.persistence.*
 
@@ -23,11 +24,11 @@ class Hotplace(
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val imgURL: String?,
 
-    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
-    val longitude: String,
+    @Column(columnDefinition = "DECIMAL(20, 12)", nullable = false)
+    val longitude: Double,
 
-    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
-    val latitude: String,
+    @Column(columnDefinition = "DECIMAL(20, 12)", nullable = false)
+    val latitude: Double,
 
     @Enumerated(EnumType.STRING)
     val approveStatus: ApproveStatus,

--- a/hotspot-domain/src/main/kotlin/com/dol/domain/hotplace/repository/HotplaceRepository.kt
+++ b/hotspot-domain/src/main/kotlin/com/dol/domain/hotplace/repository/HotplaceRepository.kt
@@ -5,4 +5,10 @@ import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
 interface HotplaceRepository : CrudRepository<Hotplace, UUID> {
+    fun findAllByLatitudeBetweenAndLongitudeBetween(
+        startLatitude: Double,
+        endLatitude: Double,
+        startLongitude: Double,
+        endLongitude: Double
+    ):List<Hotplace>
 }


### PR DESCRIPTION
## 💡 개요
현재 위치 기준 2km내에 있는 핫플레이스를 조회하는 api를 작성하였습니다
## 📃 작업내용
핫플레이스 조회 service / controller / request / response
## 🔀 변경사항
hotplace 엔티티의 위도 경도 필드의 자료형이 Double로 다시 바뀌었습니다